### PR TITLE
add SplitMix64::next_u32 from dsiutils

### DIFF
--- a/src/splitmix64.rs
+++ b/src/splitmix64.rs
@@ -29,7 +29,11 @@ impl SplitMix64 {
 impl RngCore for SplitMix64 {
     #[inline]
     fn next_u32(&mut self) -> u32 {
-        self.next_u64() as u32
+        self.x = self.x.wrapping_add(0x9e3779b97f4a7c15);
+        let mut z = self.x;
+        z = (z ^ (z >> 33)).wrapping_mul(0x62A9D9ED799705F5);
+        z = (z ^ (z >> 28)).wrapping_mul(0xCB24D0A5C88C35B3);
+        (z >> 32) as u32
     }
 
     #[inline]


### PR DESCRIPTION
[`dsiutils`](http://dsiutils.di.unimi.it/) has a 32-bit method for SplitMix64 as well as 64-bit. Perhaps not very useful (and also a breaking change?) but it'd be nice have.
```
// 2^10 calls to each
test splitmix32 ... bench:       2,929 ns/iter (+/- 869)
test splitmix64 ... bench:       3,630 ns/iter (+/- 516)
